### PR TITLE
fix node comments in kdl

### DIFF
--- a/kak/autoload/filetype/kdl.kak
+++ b/kak/autoload/filetype/kdl.kak
@@ -21,7 +21,8 @@ provide-module kdl %§
     add-highlighter shared/kdl                   regions
     add-highlighter shared/kdl/props             default-region group
     add-highlighter shared/kdl/comment           region "//" "$"                        ref comment
-    add-highlighter shared/kdl/slash_dash        region -recurse "\{" "/-" "\}"         ref comment
+    add-highlighter shared/kdl/slash_dash        region "/-" "$"                        ref comment
+    add-highlighter shared/kdl/slash_dash_child  region -recurse "\{" "/-.*\{$" "\}"    ref comment
     add-highlighter shared/kdl/slash_star        region -recurse "/\*" "/\*" "\*/"      ref comment
     add-highlighter shared/kdl/string            region %{(?<!')"} %{(?<!\\)(\\\\)*"}       fill string
     add-highlighter shared/kdl/raw_string        region -match-capture %{(#*)"} %{"(#*)}    fill string


### PR DESCRIPTION
Hi! I based my kdl.kak on yours, and I fixed one thing that might be really helpful. 

Before this change, when commenting out an entire node, the comment would leak into subsequent nodes, because the first `{` should not be recursed into. I also added single-line node comment.

Sadly, this will not work if a node is split between many lines or brace is not on the same line as node start (not sure if the second one is even valid kdl?)
```kdl
node 1 2 \
     3 4

node \
{
    node2 ...
}
```
I'm not sure if it's possible to handle those cases without a full blown parser like treesitter... 
But obviously this should be better that before. 

Cheers!